### PR TITLE
Fix case in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Cette version majeure introduit des fonctionnalités très attendues pour une ex
 1.  **Cloner le projet**
     ```bash
     git clone https://github.com/GaetanAff/StudyBoost.git
-    cd studyboost
+    cd StudyBoost
     ```
    
 2.  **Installer les dépendances**


### PR DESCRIPTION
## Summary
- update README to use correct directory name `StudyBoost`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f6367bfc4832d913cb80bdbe03d36