### PR TITLE
Add progress tracking and history modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Cette version majeure introduit des fonctionnalités très attendues pour une ex
 * **Mode Sombre** : Changez de thème pour un meilleur confort visuel.
 * **Support Multi-langues** : Interface disponible en Français, Anglais, Allemand, Espagnol.
 * **Suivi des Tokens** : Gardez un œil sur votre utilisation de l'API Gemini avec un affichage numérique et un diagramme circulaire pour les tokens d'entrée.
+* **Historique et progression** : Consultez vos actions passées et suivez vos scores directement dans l'application.
 
 
 ## 📋 Prérequis

--- a/public/index.html
+++ b/public/index.html
@@ -38,6 +38,9 @@
                     <button id="apiKeyBtn" class="btn-secondary">
                         <i class="fas fa-key"></i> <span data-lang="apiKeyBtnLabel">Clé API</span>
                     </button>
+                    <button id="progressBtn" class="btn-secondary">
+                        <i class="fas fa-chart-line"></i> <span data-lang="progressBtnLabel">Progression</span>
+                    </button>
                 </div>
             </div>
         </header>
@@ -209,6 +212,21 @@
                     </div>
                 <div class="modal-footer">
                     <button id="confirmOptions" class="btn-primary" data-lang="generateBtnLabel">Générer</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="modal" id="progressModal">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3 data-lang="progressModalTitle">Historique</h3>
+                    <button class="modal-close" type="button">&times;</button>
+                </div>
+                <div class="modal-body">
+                    <div id="historyContainer"></div>
+                </div>
+                <div class="modal-footer">
+                    <button id="clearHistoryBtn" class="btn-secondary" data-lang="clearHistoryBtnLabel">Effacer l'historique</button>
                 </div>
             </div>
         </div>

--- a/public/script.js
+++ b/public/script.js
@@ -9,7 +9,9 @@ class StudyBoostApp {
         this.currentFlashcardsData = null;
         this.generatedOpenQuestion = null; // To store the AI-generated open question
 
-        this.dailyInputTokenLimit = 1048576; 
+        this.history = [];
+        
+        this.dailyInputTokenLimit = 1048576;
 
         this.currentLanguage = localStorage.getItem('studyboost_language') || 'fr';
         this.translations = window.STUDYBOOST_TRANSLATIONS || {};
@@ -21,8 +23,10 @@ class StudyBoostApp {
         this.setupEventListeners();
         this.checkApiKey();
         this.updateTokenDisplay();
-        this.setLanguage(this.currentLanguage); 
+        this.setLanguage(this.currentLanguage);
         this.setInitialDarkMode();
+        this.loadHistory();
+        this.renderHistory();
     }
     
     setLanguage(lang) {
@@ -130,6 +134,53 @@ class StudyBoostApp {
         this.updateTokenDisplay();
     }
 
+    loadHistory() {
+        try {
+            this.history = JSON.parse(localStorage.getItem('studyboost_history')) || [];
+        } catch (e) {
+            this.history = [];
+        }
+    }
+
+    saveHistory() {
+        localStorage.setItem('studyboost_history', JSON.stringify(this.history));
+    }
+
+    addHistoryEntry(action, details = {}) {
+        const entry = {
+            timestamp: new Date().toISOString(),
+            document: this.currentDocument?.filename || '',
+            action,
+            details
+        };
+        this.history.push(entry);
+        this.saveHistory();
+        this.renderHistory();
+    }
+
+    clearHistory() {
+        this.history = [];
+        this.saveHistory();
+        this.renderHistory();
+    }
+
+    renderHistory() {
+        const container = document.getElementById('historyContainer');
+        if (!container) return;
+        if (this.history.length === 0) {
+            container.innerHTML = `<p>${this._('noHistoryMessage')}</p>`;
+            return;
+        }
+        let html = '<table class="history-table"><thead><tr><th>' + this._('dateLabel') + '</th><th>' + this._('processedDocumentLabel') + '</th><th>' + this._('resultsTitleLabel') + '</th><th>' + this._('detailsLabel') + '</th></tr></thead><tbody>';
+        this.history.forEach(entry => {
+            const date = new Date(entry.timestamp).toLocaleString();
+            const details = entry.details && entry.details.score ? entry.details.score : (entry.details.numQuestions ? entry.details.numQuestions + ' Q' : '');
+            html += `<tr><td>${date}</td><td>${entry.document}</td><td>${entry.action}</td><td>${details}</td></tr>`;
+        });
+        html += '</tbody></table>';
+        container.innerHTML = html;
+    }
+
     replaceEmojiCodes(text) {
         const map = {
             ":)": "🙂",
@@ -186,6 +237,8 @@ class StudyBoostApp {
         document.getElementById('darkModeToggle')?.addEventListener('click', () => this.toggleDarkMode());
         document.getElementById('languageSwitcher')?.addEventListener('change', (e) => this.setLanguage(e.target.value));
         document.getElementById('testApiKeyBtn')?.addEventListener('click', () => this.testApiKey());
+        document.getElementById('progressBtn')?.addEventListener('click', () => { this.renderHistory(); this.showModal('progressModal'); });
+        document.getElementById('clearHistoryBtn')?.addEventListener('click', () => this.clearHistory());
 
         // *** AJOUT CRUCIAL : Listener pour le bouton de bascule de visibilité de la clé API ***
         const apiKeyModalElement = document.getElementById('apiKeyModal');
@@ -582,10 +635,11 @@ class StudyBoostApp {
             const result = await response.json();
 
             if (response.ok && result.success && result.content && typeof result.content.text !== 'undefined') {
-                this.showResults(type, result.content.text); 
+                this.showResults(type, result.content.text);
+                this.addHistoryEntry(type, options);
                 if (result.content.usage) {
                     const promptTokens = result.content.usage.promptTokenCount || 0;
-                    const candidatesTokens = result.content.usage.candidatesTokenCount || 0; 
+                    const candidatesTokens = result.content.usage.candidatesTokenCount || 0;
                     this.updateStoredTokens(promptTokens, candidatesTokens);
                 }
             } else {
@@ -649,16 +703,17 @@ class StudyBoostApp {
                          cleanedContent = cleanedContent.substring(3, cleanedContent.length - 3).trim();
                     }
                     
-                    parsableJSON = cleanedContent;
-                    const arrayMatch = cleanedContent.match(/(\[[\s\S]*\])/);
-                    if (arrayMatch && arrayMatch[1]) {
-                        parsableJSON = arrayMatch[1];
-                    }
+                parsableJSON = cleanedContent;
+                const arrayMatch = cleanedContent.match(/(\[[\s\S]*\])/);
+                if (arrayMatch && arrayMatch[1]) {
+                    parsableJSON = arrayMatch[1];
+                }
 
-                    this.currentQCMData = JSON.parse(parsableJSON); 
-                    html = this.formatQCM(this.currentQCMData);
-                    resultsContent.innerHTML = html;
-                    this.setupQCMInteractions();
+                this.currentQCMData = JSON.parse(parsableJSON);
+                this.qcmScore = { total: 0, correct: 0 };
+                html = this.formatQCM(this.currentQCMData);
+                resultsContent.innerHTML = html;
+                this.setupQCMInteractions();
                 } catch (e) {
                     console.error("Error parsing QCM JSON:", e, "\nRaw content:", content, "\nAttempted to parse:", parsableJSON || content);
                     html = `<div class="markdown-content"><p>${this._('notificationQCMFormatError')} ${this._('checkConsoleForDetails')}</p><p>Raw output:</p><pre>${content}</pre></div>`;
@@ -770,7 +825,24 @@ class StudyBoostApp {
                     input.disabled = true; 
                 });
                 qcmItem.querySelector('.qcm-explanation')?.classList.add('visible');
-                button.disabled = true; 
+                button.disabled = true;
+
+                if (!qcmItem.dataset.answered) {
+                    this.qcmScore.total++;
+                    if (userAnswerLetter === correctAnswerLetter) {
+                        this.qcmScore.correct++;
+                    }
+                    qcmItem.dataset.answered = 'true';
+                    if (this.qcmScore.total === this.currentQCMData.length) {
+                        this.showNotification(`Score: ${this.qcmScore.correct}/${this.qcmScore.total}`, 'info');
+                        const last = this.history[this.history.length - 1];
+                        if (last && last.action === 'qcm') {
+                            last.details.score = `${this.qcmScore.correct}/${this.qcmScore.total}`;
+                            this.saveHistory();
+                            this.renderHistory();
+                        }
+                    }
+                }
             }
         });
     }

--- a/public/styles.css
+++ b/public/styles.css
@@ -478,6 +478,14 @@ body.dark-mode .qcm-explanation { background: rgba(var(--text-secondary-dark-rgb
 .flashcard-back { background: var(--surface); border: 1px solid var(--border); transform: rotateY(180deg); }
 .flashcard-content { overflow-y: auto; max-height: 100%; }
 
+/* History Table */
+.history-table { width: 100%; border-collapse: collapse; }
+.history-table th, .history-table td { padding: 0.5rem; border: 1px solid var(--border); text-align: left; }
+.history-table th { background: var(--surface); }
+.history-table td { background: var(--background); }
+body.dark-mode .history-table th { background: var(--surface); }
+body.dark-mode .history-table td { background: var(--background); }
+
 
 /* Modals */
 .modal { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.5); display: none; justify-content: center; align-items: center; z-index: 1000; }

--- a/public/translations.js
+++ b/public/translations.js
@@ -100,6 +100,12 @@ window.STUDYBOOST_TRANSLATIONS = {
                 showPasswordIcon: "👁️", // Add this
                 hidePasswordIcon: "🙈", // Add this
                 apiKeyStatusTitle: "Statut de la clé API",
+                progressBtnLabel: "Progression",
+                progressModalTitle: "Historique & Progression",
+                clearHistoryBtnLabel: "Effacer l'historique",
+                noHistoryMessage: "Aucune donnée de progression",
+                dateLabel: "Date",
+                detailsLabel: "Détails",
             },
             en: {
                 appTitle: "StudyBoost - AI Study Assistant",
@@ -201,6 +207,12 @@ window.STUDYBOOST_TRANSLATIONS = {
                 showPasswordIcon: "👁️",
                 hidePasswordIcon: "🙈",
                 apiKeyStatusTitle: "API Key Status",
+                progressBtnLabel: "Progress",
+                progressModalTitle: "History & Progress",
+                clearHistoryBtnLabel: "Clear History",
+                noHistoryMessage: "No progress data",
+                dateLabel: "Date",
+                detailsLabel: "Details",
             },
             de: {
                 appTitle: "StudyBoost - KI-Lernassistent",
@@ -302,6 +314,12 @@ window.STUDYBOOST_TRANSLATIONS = {
                 showPasswordIcon: "👁️",
                 hidePasswordIcon: "🙈",
                 apiKeyStatusTitle: "API-Schlüsselstatus",
+                progressBtnLabel: "Fortschritt",
+                progressModalTitle: "Verlauf & Fortschritt",
+                clearHistoryBtnLabel: "Verlauf löschen",
+                noHistoryMessage: "Keine Fortschrittdaten",
+                dateLabel: "Datum",
+                detailsLabel: "Details",
             },
             es: {
                 appTitle: "StudyBoost - Asistente de Estudio IA",
@@ -403,5 +421,11 @@ window.STUDYBOOST_TRANSLATIONS = {
                 showPasswordIcon: "👁️",
                 hidePasswordIcon: "🙈",
                 apiKeyStatusTitle: "⏳ Estado de la Clave API",
+                progressBtnLabel: "Progreso",
+                progressModalTitle: "Historial y Progreso",
+                clearHistoryBtnLabel: "Borrar historial",
+                noHistoryMessage: "No hay datos de progreso",
+                dateLabel: "Fecha",
+                detailsLabel: "Detalles",
             }
         };


### PR DESCRIPTION
## Summary
- add progress tracking button and modal
- store user history in localStorage with scores for QCM
- new styles for progress table
- update translations for new labels
- document the new feature in README

## Testing
- `npm run build` *(fails: Can't resolve './src')*

------
https://chatgpt.com/codex/tasks/task_e_683f76b83764832dae9ff11f7de588db