### PR TITLE
Add navigation to session history

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Accédez à l'application via : [http://localhost:3000](http://localhost:3000)
    * Cliquez sur **"Clé API"**.
    * Sélectionnez **"Ollama"**.
    * Choisissez un modèle dans la liste déroulante (chargée automatiquement).
-   * Cliquez sur **"Tester"** pour vérifier la connexion.
+   * Cliquez sur **"Tester"** pour vérifier la connexion ou charger le modèle sélectionné.
    * **Sauvegardez.**
 
 ### ☁️ Google Gemini

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 * **Persistance locale** : toutes les sessions sont stockées dans localStorage.
 * **Traductions complètes** : libellés de gestion des sessions traduits dans toutes les langues supportées.
 * **Interface utilisateur mise à jour** : liste stylisée des sessions avec actions intuitives.
+* **Navigation dans l'historique** : flèches pour parcourir les résultats précédents d'une session.
 
 ---
 

--- a/public/index.html
+++ b/public/index.html
@@ -120,6 +120,12 @@
                 <div class="results-header">
                     <h3 id="resultsTitle" data-lang="resultsTitleLabel">Résultats</h3>
                     <div class="results-actions">
+                        <button id="prevResultBtn" class="btn-icon" title-data-lang="prevResultBtnLabel">
+                            <i class="fas fa-arrow-left"></i>
+                        </button>
+                        <button id="nextResultBtn" class="btn-icon" title-data-lang="nextResultBtnLabel">
+                            <i class="fas fa-arrow-right"></i>
+                        </button>
                         <button id="exportBtn" class="btn-secondary">
                             <i class="fas fa-download"></i> <span data-lang="exportBtnLabel">Exporter</span>
                         </button>

--- a/public/script.js
+++ b/public/script.js
@@ -19,6 +19,7 @@ class StudyBoostApp {
 
                 this.sessions = JSON.parse(localStorage.getItem('studyboost_sessions') || '{}');
                 this.currentSessionId = localStorage.getItem('studyboost_current_session') || null;
+                this.currentActionIndex = -1; // index of currently displayed action in session history
 
                 this.init();
         }
@@ -49,12 +50,18 @@ class StudyBoostApp {
 					el.textContent = this.translations[lang][key];
 				}
 			});
-			document.querySelectorAll('[placeholder-data-lang]').forEach(el => {
-				const key = el.getAttribute('placeholder-data-lang');
-				if (this.translations[lang][key]) {
-					el.placeholder = this.translations[lang][key];
-				}
-			});
+                       document.querySelectorAll('[placeholder-data-lang]').forEach(el => {
+                               const key = el.getAttribute('placeholder-data-lang');
+                               if (this.translations[lang][key]) {
+                                       el.placeholder = this.translations[lang][key];
+                               }
+                       });
+                       document.querySelectorAll('[title-data-lang]').forEach(el => {
+                                const key = el.getAttribute('title-data-lang');
+                                if (this.translations[lang][key]) {
+                                        el.setAttribute('title', this.translations[lang][key]);
+                                }
+                        });
 			const languageSwitcher = document.getElementById('languageSwitcher');
 			if (languageSwitcher) languageSwitcher.value = lang;
 			
@@ -250,8 +257,10 @@ class StudyBoostApp {
 		document.getElementById('submitQuestion')?.addEventListener('click', () => this.submitUserQuestion());
 		document.getElementById('confirmOptions')?.addEventListener('click', () => this.confirmOptions());
 		document.getElementById('newAnalysisBtn')?.addEventListener('click', () => this.resetApp());
-		document.getElementById('exportBtn')?.addEventListener('click', () => this.exportResults());
-		document.getElementById('submitOpenAnswerBtn')?.addEventListener('click', () => this.submitOpenAnswer());
+                document.getElementById('exportBtn')?.addEventListener('click', () => this.exportResults());
+                document.getElementById('submitOpenAnswerBtn')?.addEventListener('click', () => this.submitOpenAnswer());
+                document.getElementById('prevResultBtn')?.addEventListener('click', () => this.showPreviousResult());
+                document.getElementById('nextResultBtn')?.addEventListener('click', () => this.showNextResult());
 		
 		// Listener pour fermer un modal en cliquant à l'extérieur de son contenu
 		document.querySelectorAll('.modal').forEach(modal => {
@@ -871,10 +880,13 @@ class StudyBoostApp {
                 resultsSection.scrollIntoView({ behavior: 'smooth' });
 
                 if (!fromHistory && this.currentSessionId && this.sessions[this.currentSessionId]) {
-                        this.sessions[this.currentSessionId].currentDocument = this.currentDocument;
-                        this.sessions[this.currentSessionId].actions.push({ type, content, options: this.lastOptions, timestamp: Date.now() });
+                        const sess = this.sessions[this.currentSessionId];
+                        sess.currentDocument = this.currentDocument;
+                        sess.actions.push({ type, content, options: this.lastOptions, timestamp: Date.now() });
+                        this.currentActionIndex = sess.actions.length - 1;
                         this.saveSessions();
                 }
+                this.updateHistoryButtons();
         }
 	
 	
@@ -1015,22 +1027,24 @@ class StudyBoostApp {
 		}
 	}
 	
-	resetApp() {
-		this.currentDocument = null;
-		this.currentAction = null;
-		this.currentQCMData = null;
-		this.currentFlashcardsData = null;
-		this.generatedOpenQuestion = null;
+        resetApp() {
+                this.currentDocument = null;
+                this.currentAction = null;
+                this.currentQCMData = null;
+                this.currentFlashcardsData = null;
+                this.generatedOpenQuestion = null;
+                this.currentActionIndex = -1;
 		
 		document.getElementById('uploadSection').style.display = 'block';
 		document.getElementById('contentSection').style.display = 'none';
 		document.getElementById('resultsSection').style.display = 'none';
 		document.getElementById('openQuestionInteractionSection').style.display = 'none';
 		const fileInput = document.getElementById('fileInput');
-		if(fileInput) fileInput.value = '';
-		
-		this.showNotification(this._('notificationNewAnalysisReady'), 'info');
-	}
+                if(fileInput) fileInput.value = '';
+
+                this.showNotification(this._('notificationNewAnalysisReady'), 'info');
+                this.updateHistoryButtons();
+        }
 	
         showModal(modalId) {
                 const modalElement = document.getElementById(modalId);
@@ -1069,7 +1083,8 @@ class StudyBoostApp {
                 if (!sess) return;
                 this.currentSessionId = id;
                 this.currentDocument = sess.currentDocument;
-                const lastAction = sess.actions[sess.actions.length - 1];
+                this.currentActionIndex = sess.actions.length - 1;
+                const lastAction = sess.actions[this.currentActionIndex];
                 if (this.currentDocument) {
                         this.showDocumentProcessed(this.currentDocument.filename, this.currentDocument.text);
                 } else {
@@ -1079,6 +1094,7 @@ class StudyBoostApp {
                         this.currentAction = lastAction.type;
                         this.showResults(lastAction.type, lastAction.content, true);
                 }
+                this.updateHistoryButtons();
                 this.saveSessions();
         }
 
@@ -1115,10 +1131,10 @@ class StudyBoostApp {
 	}
 	hideLoading() { document.getElementById('loadingOverlay').style.display = 'none'; }
 	
-	showNotification(message, type = 'info') {
-		const notificationArea = document.body; 
-		const notification = document.createElement('div');
-		notification.className = `notification type-${type} slide-in`;
+        showNotification(message, type = 'info') {
+                const notificationArea = document.body;
+                const notification = document.createElement('div');
+                notification.className = `notification type-${type} slide-in`;
 		
 		const messageSpan = document.createElement('span');
 		messageSpan.textContent = message;
@@ -1136,14 +1152,41 @@ class StudyBoostApp {
 		
 		notificationArea.appendChild(notification);
 		
-		setTimeout(() => {
-			if (notification.parentElement) {
-				notification.classList.remove('slide-in');
-				notification.classList.add('slide-out');
-				setTimeout(() => notification.remove(), 300); 
-			}
-		}, 7000); 
-	}
+                setTimeout(() => {
+                        if (notification.parentElement) {
+                                notification.classList.remove('slide-in');
+                                notification.classList.add('slide-out');
+                                setTimeout(() => notification.remove(), 300);
+                        }
+                }, 7000);
+        }
+
+        updateHistoryButtons() {
+                const sess = this.sessions[this.currentSessionId];
+                const prevBtn = document.getElementById('prevResultBtn');
+                const nextBtn = document.getElementById('nextResultBtn');
+                if (!sess || !prevBtn || !nextBtn) return;
+                prevBtn.disabled = this.currentActionIndex <= 0;
+                nextBtn.disabled = this.currentActionIndex >= sess.actions.length - 1;
+        }
+
+        showPreviousResult() {
+                const sess = this.sessions[this.currentSessionId];
+                if (!sess || this.currentActionIndex <= 0) return;
+                this.currentActionIndex--;
+                const action = sess.actions[this.currentActionIndex];
+                this.currentAction = action.type;
+                this.showResults(action.type, action.content, true);
+        }
+
+        showNextResult() {
+                const sess = this.sessions[this.currentSessionId];
+                if (!sess || this.currentActionIndex >= sess.actions.length - 1) return;
+                this.currentActionIndex++;
+                const action = sess.actions[this.currentActionIndex];
+                this.currentAction = action.type;
+                this.showResults(action.type, action.content, true);
+        }
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/public/script.js
+++ b/public/script.js
@@ -206,11 +206,16 @@ class StudyBoostApp {
                 document.getElementById('useOllama')?.addEventListener('click', () => this.useOllama());
                 document.getElementById('useGemini')?.addEventListener('click', () => this.useGemini());
                 document.getElementById('languageSwitcher')?.addEventListener('change', (e) => this.setLanguage(e.target.value));
-                document.getElementById('testApiKeyBtn')?.addEventListener('click', () => this.testApiKey());
+                document.getElementById('testApiKeyBtn')?.addEventListener('click', () => {
+                        if (this.usingOllama) {
+                                this.testOllamaModel();
+                        } else {
+                                this.testApiKey();
+                        }
+                });
                 document.getElementById('ollamaModelSelect')?.addEventListener('change', (e) => {
                         this.selectedOllamaModel = e.target.value;
                         localStorage.setItem('ollama_model', this.selectedOllamaModel);
-                        this.testOllamaModel();
                 });
                 document.getElementById('sessionBtn')?.addEventListener('click', () => { this.renderSessionList(); this.showModal('sessionModal'); });
                 document.getElementById('createSessionBtn')?.addEventListener('click', () => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -336,6 +336,10 @@ body.dark-mode .status-error {
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s;
 }
+.btn-icon:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
 .btn-icon:hover {
     background-color: var(--border);
     color: var(--text-primary);

--- a/public/translations.js
+++ b/public/translations.js
@@ -98,7 +98,7 @@ window.STUDYBOOST_TRANSLATIONS = {
                 difficultyLevel4: "Difficile",
                 difficultyLevel5: "Expert",
                 checkAnswerBtnLabel: "Vérifier la réponse",
-                testApiKeyBtnLabel: "🧪 Tester la Clé", // Nouvelle traduction
+                testApiKeyBtnLabel: "🧪 Tester", // Nouvelle traduction
                 apiKeyTestSuccess: "✅ Clé API valide et fonctionnelle.", // Nouvelle traduction
                 apiKeyTestFailure: "❌ Clé API invalide ou problème de connexion: ", // Nouvelle traduction
                 loadingTextTestingKey: "⏳ Test de la clé API en cours...", // Nouvelle traduction pour le chargement
@@ -215,7 +215,7 @@ window.STUDYBOOST_TRANSLATIONS = {
                 difficultyLevel4: "Hard",
                 difficultyLevel5: "Expert",
                 checkAnswerBtnLabel: "Check Answer",
-                testApiKeyBtnLabel: "🧪 Test Key", // New translation
+                testApiKeyBtnLabel: "🧪 Test", // New translation
                 apiKeyTestSuccess: "✅ API key is valid and working.", // New translation
                 apiKeyTestFailure: "❌ API key is invalid or connection issue: ", // New translation
                 loadingTextTestingKey: "⏳ Testing API key...", // New translation for loading
@@ -332,7 +332,7 @@ window.STUDYBOOST_TRANSLATIONS = {
                 difficultyLevel4: "Schwer",
                 difficultyLevel5: "Experte",
                 checkAnswerBtnLabel: "Antwort überprüfen",
-                testApiKeyBtnLabel: "🧪 Schlüssel testen", // Neue Übersetzung
+                testApiKeyBtnLabel: "🧪 Testen", // Neue Übersetzung
                 apiKeyTestSuccess: "✅ API-Schlüssel ist gültig und funktioniert.", // Neue Übersetzung
                 apiKeyTestFailure: "❌ API-Schlüssel ist ungültig oder Verbindungsproblem: ", // Neue Übersetzung
                 loadingTextTestingKey: "⏳ API-Schlüssel wird getestet...", // Neue Übersetzung für das Laden
@@ -449,7 +449,7 @@ window.STUDYBOOST_TRANSLATIONS = {
                 difficultyLevel4: "Difícil",
                 difficultyLevel5: "Experto",
                 checkAnswerBtnLabel: "Verificar respuesta",
-                testApiKeyBtnLabel: "🧪 Probar Clave", // Nueva traducción
+                testApiKeyBtnLabel: "🧪 Probar", // Nueva traducción
                 apiKeyTestSuccess: "✅ La clave API es válida y funciona.", // Nueva traducción
                 apiKeyTestFailure: "❌ La clave API no es válida o hay un problema de conexión: ", // Nueva traducción
                 loadingTextTestingKey: "Probando clave API...", // Nueva traducción para la carga

--- a/public/translations.js
+++ b/public/translations.js
@@ -114,6 +114,8 @@ window.STUDYBOOST_TRANSLATIONS = {
                 deleteSessionBtnLabel: "Supprimer",
                 noSessionsMessage: "Aucune session enregistrée",
                 defaultSessionName: "Session par défaut",
+                prevResultBtnLabel: "Résultat précédent",
+                nextResultBtnLabel: "Résultat suivant",
             },
             en: {
                 appTitle: "StudyBoost - AI Study Assistant",
@@ -229,6 +231,8 @@ window.STUDYBOOST_TRANSLATIONS = {
                 deleteSessionBtnLabel: "Delete",
                 noSessionsMessage: "No sessions saved",
                 defaultSessionName: "Default Session",
+                prevResultBtnLabel: "Previous Result",
+                nextResultBtnLabel: "Next Result",
             },
             de: {
                 appTitle: "StudyBoost - KI-Lernassistent",
@@ -344,6 +348,8 @@ window.STUDYBOOST_TRANSLATIONS = {
                 deleteSessionBtnLabel: "Löschen",
                 noSessionsMessage: "Keine Sitzungen gespeichert",
                 defaultSessionName: "Standardsitzung",
+                prevResultBtnLabel: "Vorheriges Ergebnis",
+                nextResultBtnLabel: "Nächstes Ergebnis",
             },
             es: {
                 appTitle: "StudyBoost - Asistente de Estudio IA",
@@ -459,5 +465,7 @@ window.STUDYBOOST_TRANSLATIONS = {
                 deleteSessionBtnLabel: "Eliminar",
                 noSessionsMessage: "Ninguna sesión guardada",
                 defaultSessionName: "Sesión por defecto",
+                prevResultBtnLabel: "Resultado anterior",
+                nextResultBtnLabel: "Resultado siguiente",
             }
         };


### PR DESCRIPTION
## Summary
- document navigation arrows in the README
- add previous/next buttons in results section
- save displayed action index per session and show previous results
- translate navigation labels for all languages
- style disabled icon buttons

## Testing
- `npm run build:dev` *(fails: can't resolve ./src)*

------
https://chatgpt.com/codex/tasks/task_e_684ebd64a290832d8ce51f2cc37dd524