### PR TITLE
Add ODT file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * **Traductions complètes** : libellés de gestion des sessions traduits dans toutes les langues supportées.
 * **Interface utilisateur mise à jour** : liste stylisée des sessions avec actions intuitives.
 * **Navigation dans l'historique** : flèches pour parcourir les résultats précédents d'une session.
+* **Prise en charge des fichiers ODT** : conversion automatique vers DOCX avant traitement.
 
 ---
 
@@ -53,7 +54,7 @@
 
 ## ⭐ Fonctionnalités Clés
 
-* **Support de documents multiples** : PDF, Word, PowerPoint, Images (avec OCR).
+* **Support de documents multiples** : PDF, Word (DOCX/ODT), PowerPoint, Images (avec OCR).
 * **Choix du moteur IA** : Google Gemini (cloud) ou Ollama (local).
 * **Résumé intelligent** (court ou détaillé, au format Markdown).
 * **QCM personnalisables** : niveau de difficulté, réponses, explications.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.21.2",
         "html2canvas": "^1.4.1",
         "jspdf": "^2.5.2",
+        "libreoffice-convert": "^1.6.1",
         "mammoth": "^1.9.1",
         "marked": "^9.1.6",
         "multer": "^1.4.5-lts.1",
@@ -510,6 +511,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
     "node_modules/atob": {
@@ -1798,6 +1805,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/libreoffice-convert": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/libreoffice-convert/-/libreoffice-convert-1.6.1.tgz",
+      "integrity": "sha512-j4YtAp8/5EZIGPH1zyzuPHYXBTUXDWvDyDxJY1w67Fw7F2qryvMlYnl6W0cUZN9yWs6aZCG0Ix2/RePOlvh1bA==",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.3",
+        "tmp": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -2996,6 +3016,15 @@
       "license": "MIT",
       "dependencies": {
         "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "express": "^4.21.2",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.2",
+    "libreoffice-convert": "^1.6.1",
     "mammoth": "^1.9.1",
     "marked": "^9.1.6",
     "multer": "^1.4.5-lts.1",

--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,7 @@
                     <p data-lang="uploadSubtitle">PDF, Word, PowerPoint, Images (OCR)</p>
                     
                     <div class="upload-area" id="uploadArea">
-                        <input type="file" id="fileInput" accept=".pdf,.doc,.docx,.ppt,.pptx,.jpg,.jpeg,.png" hidden>
+                        <input type="file" id="fileInput" accept=".pdf,.doc,.docx,.odt,.ppt,.pptx,.jpg,.jpeg,.png" hidden>
                         <div class="upload-placeholder">
                             <i class="fas fa-plus"></i>
                             <span data-lang="uploadPlaceholder">Cliquez ou glissez vos fichiers ici</span>

--- a/server.js
+++ b/server.js
@@ -35,14 +35,14 @@ const storage = multer.diskStorage({
 const upload = multer({ 
   storage: storage,
   fileFilter: (req, file, cb) => {
-    const allowedTypes = /pdf|doc|docx|ppt|pptx|jpg|jpeg|png/;
+    const allowedTypes = /pdf|doc|docx|odt|ppt|pptx|jpg|jpeg|png/;
     const extname = allowedTypes.test(path.extname(file.originalname).toLowerCase());
     const mimetype = allowedTypes.test(file.mimetype);
     
     if (mimetype && extname) {
       return cb(null, true);
     } else {
-      cb(new Error('Type de fichier non supporté. Formats autorisés : PDF, DOC, DOCX, PPT, PPTX, JPG, JPEG, PNG.'));
+      cb(new Error('Type de fichier non supporté. Formats autorisés : PDF, DOC, DOCX, ODT, PPT, PPTX, JPG, JPEG, PNG.'));
     }
   },
   limits: { fileSize: 10 * 1024 * 1024 } // 10MB max

--- a/utils/documentProcessor.js
+++ b/utils/documentProcessor.js
@@ -3,6 +3,9 @@ const mammoth = require('mammoth');
 const fs = require('fs');
 const path = require('path');
 const Tesseract = require('tesseract.js');
+const libre = require('libreoffice-convert');
+const util = require('util');
+libre.convertAsync = util.promisify(libre.convert);
 
 async function processDocument(filePath) {
   const ext = path.extname(filePath).toLowerCase();
@@ -14,6 +17,13 @@ async function processDocument(filePath) {
       case '.doc':
       case '.docx':
         return await processWord(filePath);
+      case '.odt':
+        const convertedPath = await convertToDocx(filePath);
+        const text = await processWord(convertedPath);
+        fs.unlink(convertedPath, err => {
+          if (err) console.error('Erreur suppression fichier converti:', err);
+        });
+        return text;
       case '.jpg':
       case '.jpeg':
       case '.png':
@@ -36,6 +46,17 @@ async function processPDF(filePath) {
 async function processWord(filePath) {
   const result = await mammoth.extractRawText({ path: filePath });
   return result.value;
+}
+
+async function convertToDocx(inputPath) {
+  const outputPath = path.join(
+    path.dirname(inputPath),
+    `${path.parse(inputPath).name}.docx`
+  );
+  const file = await fs.promises.readFile(inputPath);
+  const converted = await libre.convertAsync(file, '.docx', undefined);
+  await fs.promises.writeFile(outputPath, converted);
+  return outputPath;
 }
 
 async function processImage(filePath) {


### PR DESCRIPTION
## Summary
- add libreoffice-convert to dependencies
- convert `.odt` files to `.docx` in `documentProcessor`
- allow ODT upload on server and in client file picker
- document ODT support in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852953af8f8832d90b69c1e6e012fb3