### PR TITLE
Add LibreOffice requirement and config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ npm install
 sudo apt-get install libreoffice -y
 ```
 
+Si la commande `soffice` n'est pas détectée, indiquez son chemin via la
+variable d'environnement `SOFFICE_PATH` :
+
+```bash
+export SOFFICE_PATH=/chemin/vers/soffice
+# Sous Windows
+set SOFFICE_PATH="C:\\Program Files\\LibreOffice\\program\\soffice.exe"
+```
+
 ### Lancement
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 * **NPM** ou **Yarn**
 * Clé API **Google Gemini** *(via [Google AI Studio](https://makersuite.google.com/app))* (pour le mode cloud)
 * **Ollama** installé et actif avec au moins un modèle (ex: `ollama run llama3`)
+* **LibreOffice** installé pour permettre la conversion des fichiers ODT/Word (commande `soffice`)
 
 ---
 
@@ -84,6 +85,8 @@
 git clone https://github.com/GaetanAff/StudyBoost.git
 cd StudyBoost
 npm install
+# Installer LibreOffice (pour la conversion des documents)
+sudo apt-get install libreoffice -y
 ```
 
 ### Lancement

--- a/utils/documentProcessor.js
+++ b/utils/documentProcessor.js
@@ -5,6 +5,7 @@ const path = require('path');
 const Tesseract = require('tesseract.js');
 const libre = require('libreoffice-convert');
 libre.convertAsync = require('util').promisify(libre.convert);
+const libreOptions = process.env.SOFFICE_PATH ? { sofficeBinaryPaths: [process.env.SOFFICE_PATH] } : {};
 
 async function processDocument(filePath) {
   const ext = path.extname(filePath).toLowerCase();
@@ -48,7 +49,7 @@ async function processODT(filePath) {
   const outputPath = path.join(__dirname, '../uploads/output.docx');
 
   const odtBuf = await fs.promises.readFile(inputPath);
-  const docxBuf = await libre.convertAsync(odtBuf, ext, undefined);
+  const docxBuf = await libre.convertAsync(odtBuf, ext, libreOptions);
   fs.writeFileSync(outputPath, docxBuf);
   const text = await processWord(outputPath);
   fs.unlink(outputPath, () => {});

--- a/utils/documentProcessor.js
+++ b/utils/documentProcessor.js
@@ -5,7 +5,10 @@ const path = require('path');
 const Tesseract = require('tesseract.js');
 const libre = require('libreoffice-convert');
 libre.convertAsync = require('util').promisify(libre.convert);
-const libreOptions = process.env.SOFFICE_PATH ? { sofficeBinaryPaths: [process.env.SOFFICE_PATH] } : {};
+libre.convertWithOptionsAsync = require('util').promisify(libre.convertWithOptions);
+const libreOptions = process.env.SOFFICE_PATH
+  ? { sofficeBinaryPaths: [process.env.SOFFICE_PATH] }
+  : {};
 
 async function processDocument(filePath) {
   const ext = path.extname(filePath).toLowerCase();
@@ -49,7 +52,12 @@ async function processODT(filePath) {
   const outputPath = path.join(__dirname, '../uploads/output.docx');
 
   const odtBuf = await fs.promises.readFile(inputPath);
-  const docxBuf = await libre.convertAsync(odtBuf, ext, libreOptions);
+  const docxBuf = await libre.convertWithOptionsAsync(
+    odtBuf,
+    ext,
+    undefined,
+    libreOptions
+  );
   fs.writeFileSync(outputPath, docxBuf);
   const text = await processWord(outputPath);
   fs.unlink(outputPath, () => {});


### PR DESCRIPTION
## Summary
- document LibreOffice as required dependency
- show install command in setup instructions
- allow overriding soffice path via `SOFFICE_PATH`

## Testing
- `npm run build` *(fails: Can't resolve './src')*

------
https://chatgpt.com/codex/tasks/task_e_68529aa345e0832d90aefbb8b5c46228